### PR TITLE
Use animation end for confetti cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,15 +513,11 @@
                     const delay = Math.random() * 0.5;
                     
                     // Use CSS animation for better performance on mobile
-                    confetti.style.animation = `confetti-pop 0.3s forwards, 
+                    confetti.style.animation = `confetti-pop 0.3s forwards,
                                                confetti-fall ${duration}s ${delay}s forwards`;
-                    
-                    // Remove after animation
-                    setTimeout(() => {
-                        if (confetti.parentNode) {
-                            confetti.parentNode.removeChild(confetti);
-                        }
-                    }, (duration + delay) * 1000 + 100);
+
+                    // Remove element when animation completes
+                    confetti.addEventListener('animationend', () => confetti.remove());
                 }
             }
             


### PR DESCRIPTION
## Summary
- Remove timeout-based cleanup of confetti elements
- Use `animationend` event to remove confetti when animations complete

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3f9b33ccc832fbc04e698d6fc4873