### PR TITLE
Ensure slot icons render at consistent size

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,8 +122,9 @@
         }
         
         .reel-item img {
-            width: 80%;
             height: 80%;
+            width: auto;
+            max-width: 80%;
             object-fit: contain;
         }
         


### PR DESCRIPTION
## Summary
- adjust CSS for slot machine icons to keep heights consistent and prevent oversized images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3fd6e2a40832f8e35e036bbdb8eca